### PR TITLE
Updated flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,31 @@ From examples\square\square.go:
         return iX >= max
     }
 
+## Flags
+
+Etherdream library will intialize the following flags - use -help for more info:
+
+    -blank-count int
+        How many samples to wait after drawing a blanking line. (default 20)
+    -debug
+        Enable debug output.
+    -draw-speed float
+        Draw speed (25-100). Lower is more precision but slower. (default 50)
+    -scan-rate int
+        Number of points per second to play back. (default 24000)
+
 ## Blanking and Paths
 
 Here we introduce the use of [tgreiser/ln](https://github.com/tgreiser/ln), a fork of Fogleman's excellent [ln](https://github.com/fogleman/ln) 3D vector library. Blanking is used to reposition the laser to a new location, it involves turning off the beam, repositioning and then a pause. The exact pause necessary to clean up an image can vary from projector to projector so this can be easily configured. I am using the methodology outlined in [Accurate and Efficient Drawing Method for Laser Projection](http://www.art-science.org/journal/v7n4/v7n4pp155/artsci-v7n4pp155.pdf)
 
 If you just want to configure your projector, use examples\parallel_lines\lines.go
 
-    go run examples\parallel_lines\lines.go -pre-blank-count=1 -post-blank-count=5
+    go run examples\parallel_lines\lines.go -blank-count=5
     # Without sufficient post-blank-count, it produce diagonal lines that cut across most of the image.
     
 ![Not blanking](http://prim8.net/art/lines_unblanked.jpg)
     
-    go run examples\parallel_lines\lines.go -pre-blank-count=0 -post-blank-count=17
+    go run examples\parallel_lines\lines.go -blank-count=17
     # These settings look pretty good on my 30 KPPS projectors. You can still see a small flaw at 17.
     
 ![Blanking](http://prim8.net/art/lines_blanked.jpg)

--- a/draw.go
+++ b/draw.go
@@ -17,22 +17,28 @@
 package etherdream
 
 import (
+	"flag"
 	"image/color"
 	"io"
 
 	"github.com/tgreiser/ln/ln"
 )
 
-// PreBlankCount is the number of blank samples to insert before moving
-var PreBlankCount = 0
-
-// PostBlankCount is the number of blank samples to insert after moving
-var PostBlankCount = 20
+// BlankCount is the number of blank samples to insert after moving
+var BlankCount = flag.Int("blank-count", 20, "How many samples to wait after drawing a blanking line.")
 
 // DrawSpeed affects how many points will be sampled on your lines. Lower is
 // more precise, but is more likely to flicker. Higher values will give smoother
 // playback, but there may be gaps around corners. Try values 25-100.
-var DrawSpeed = 50.0
+var DrawSpeed = flag.Float64("draw-speed", 50.0, "Draw speed (25-100). Lower is more precision but slower.")
+
+// Debug mode
+var Debug = flag.Bool("debug", false, "Enable debug output.")
+
+// set up flags
+func init() {
+	flag.Parse()
+}
 
 // NumberOfSegments to use when interpolating the path
 func NumberOfSegments(p ln.Path, drawSpeed float64) float64 {
@@ -43,7 +49,7 @@ func NumberOfSegments(p ln.Path, drawSpeed float64) float64 {
 // qual will override the LineQuality (see above).
 func DrawPath(w io.WriteCloser, p ln.Path, c color.Color, drawSpeed float64) {
 	if drawSpeed == 0.0 {
-		drawSpeed = DrawSpeed
+		drawSpeed = *DrawSpeed
 	}
 	dist := p[1].Sub(p[0])
 
@@ -59,11 +65,7 @@ func DrawPath(w io.WriteCloser, p ln.Path, c color.Color, drawSpeed float64) {
 
 // BlankPath will necessary pauses to effectively blank a path
 func BlankPath(w io.WriteCloser, p ln.Path) {
-	for i := 1; i <= PreBlankCount; i++ {
-		w.Write(NewPoint(int(p[0].X), int(p[0].Y), BlankColor).Encode())
-	}
-
-	for i := 1; i <= PostBlankCount; i++ {
+	for i := 1; i <= *BlankCount; i++ {
 		w.Write(NewPoint(int(p[1].X), int(p[1].Y), BlankColor).Encode())
 	}
 }

--- a/examples/circle/circle.go
+++ b/examples/circle/circle.go
@@ -45,8 +45,7 @@ func main() {
 	}
 	defer dac.Close()
 
-	debug := false
-	dac.Play(pointStream, debug)
+	dac.Play(pointStream)
 }
 
 func pointStream(w io.WriteCloser) {

--- a/examples/ln1/ln1.go
+++ b/examples/ln1/ln1.go
@@ -43,8 +43,7 @@ func main() {
 	}
 	defer dac.Close()
 
-	debug := false
-	dac.Play(pointStream, debug)
+	dac.Play(pointStream)
 }
 
 func pointStream(w io.WriteCloser) {

--- a/examples/ln2/ln2.go
+++ b/examples/ln2/ln2.go
@@ -31,8 +31,6 @@ import (
 	"github.com/tgreiser/ln/ln"
 )
 
-var speed = flag.Float64("draw-speed", 50.0, "Draw speed (25-100). Lower is more precision but slower.")
-
 func main() {
 	flag.Parse()
 	log.Printf("Listening...\n")
@@ -49,8 +47,7 @@ func main() {
 	}
 	defer dac.Close()
 
-	debug := false
-	dac.Play(pointStream, debug)
+	dac.Play(pointStream)
 }
 
 func cube(x, y, z float64) ln.Shape {
@@ -92,7 +89,7 @@ func pointStream(w io.WriteCloser) {
 			if iX+1 < lp {
 				p2 = paths[iX+1]
 			}
-			etherdream.DrawPath(w, p, c, *speed)
+			etherdream.DrawPath(w, p, c, 0.0)
 			if p2[0].Distance(p[1]) > 0 {
 				etherdream.BlankPath(w, ln.Path{p[1], p2[0]})
 			}

--- a/examples/parallel_lines/lines.go
+++ b/examples/parallel_lines/lines.go
@@ -24,21 +24,11 @@ import (
 
 	"image/color"
 
-	"flag"
-
 	"github.com/tgreiser/etherdream"
 	"github.com/tgreiser/ln/ln"
 )
 
-var speed = flag.Float64("draw-speed", 50.0, "Draw speed (25-100). Lower is more precision but slower.")
-var preBlank = flag.Int("pre-blank-count", 0, "How many samples to wait before drawing a blanking line.")
-var postBlank = flag.Int("post-blank-count", 20, "How many samples to wait after drawing a blanking line.")
-
 func main() {
-	flag.Parse()
-	etherdream.PreBlankCount = *preBlank
-	etherdream.PostBlankCount = *postBlank
-
 	log.Printf("Listening...\n")
 	addr, _, err := etherdream.FindFirstDAC()
 	if err != nil {
@@ -53,8 +43,7 @@ func main() {
 	}
 	defer dac.Close()
 
-	debug := false
-	dac.Play(pointStream, debug)
+	dac.Play(pointStream)
 }
 
 func line(x, y, z, x2, y2, z2 float64) ln.Path {
@@ -93,7 +82,7 @@ func pointStream(w io.WriteCloser) {
 			if iX%2 == 0 {
 				c = c2
 			}
-			etherdream.DrawPath(w, p, c, *speed)
+			etherdream.DrawPath(w, p, c, 0.0)
 			if p2[0].Distance(p[1]) > 0 {
 				etherdream.BlankPath(w, ln.Path{p[1], p2[0]})
 			}

--- a/examples/spiral/spiral.go
+++ b/examples/spiral/spiral.go
@@ -45,8 +45,7 @@ func main() {
 	}
 	defer dac.Close()
 
-	debug := false
-	dac.Play(pointStream, debug)
+	dac.Play(pointStream)
 }
 
 func pointStream(w io.WriteCloser) {

--- a/examples/square/square.go
+++ b/examples/square/square.go
@@ -45,8 +45,7 @@ func main() {
 	log.Printf("Initialized:  %v\n\n", dac.LastStatus)
 	log.Printf("Firmware String: %v\n\n", dac.FirmwareString)
 
-	debug := false
-	dac.Play(squarePointStream, debug)
+	dac.Play(squarePointStream)
 }
 
 func squarePointStream(w io.WriteCloser) {


### PR DESCRIPTION
Any script can take:
    -blank-count int
        How many samples to wait after drawing a blanking line. (default 20)
    -debug
        Enable debug output.
    -draw-speed float
        Draw speed (25-100). Lower is more precision but slower. (default 50)
    -scan-rate int
        Number of points per second to play back. (default 24000)